### PR TITLE
Refactor formatted/unformatted log flow

### DIFF
--- a/Aspen/AspenHelpers.swift
+++ b/Aspen/AspenHelpers.swift
@@ -32,5 +32,5 @@ extension Aspen
 	public class func willLog(level: DefaultLogLevel) -> Bool { return self.globalLogger.willLog(level) }
 
 	@objc(logWithLevel:message:)
-	public class func log(level: DefaultLogLevel, message: String!) { self.globalLogger.log(level, message: message) }	
+	public class func log(level: DefaultLogLevel, message: String!) { self.globalLogger.logFormatted(level, message: message) }
 }

--- a/Aspen/LogFormatter.swift
+++ b/Aspen/LogFormatter.swift
@@ -38,7 +38,7 @@ public class LogFormatter: NSObject
         super.init()
     }
     
-    public func formatLog(logger: Logger, level: DefaultLogLevel, message: String) -> String
+    public func formatLog(level: DefaultLogLevel, message: String) -> String
     {
         let logLevel = LogLevel.getLevel(level)
         let levelName = logLevel.label

--- a/Aspen/Logger.swift
+++ b/Aspen/Logger.swift
@@ -63,7 +63,7 @@ public class Logger: NSObject
 		return logLevel.rawValue >= level.level.rawValue
 	}
 
-	public func log(logLevel: DefaultLogLevel, @autoclosure message: () -> String)
+	func log(logLevel: DefaultLogLevel, @autoclosure message: () -> String)
 	{
 		if activeLoggers.count == 0
 		{
@@ -82,33 +82,32 @@ public class Logger: NSObject
 		}
 	}
 
+	func logFormatted(logLevel: DefaultLogLevel, @autoclosure message: () -> String)
+	{
+		log(logLevel, message: formatter.formatLog(logLevel, message: message()))
+	}
+}
+
+/** Convenience / shorthand logging functions for predefined log levels. */
+extension Logger
+{
 	public func verbose(@autoclosure message: () -> String)
 	{
-		outputToLog(.Verbose, message: message)
+		logFormatted(.Verbose, message: message)
 	}
 
 	public func info(@autoclosure message: () -> String)
 	{
-		outputToLog(.Info, message: message)
+		logFormatted(.Info, message: message)
 	}
 
 	public func warn(@autoclosure message: () -> String)
 	{
-		outputToLog(.Warning, message: message)
+		logFormatted(.Warning, message: message)
 	}
 
 	public func error(@autoclosure message: () -> String)
 	{
-		outputToLog(.Error, message: message)
-	}
-
-	// MARK: Private/Convenience
-	// ====================================
-	// Private/Convenience
-	// ====================================
-	private func outputToLog(level: DefaultLogLevel, @autoclosure message: () -> String)
-	{
-		let logLevel = level
-		log(logLevel, message: formatter.formatLog(self, level: logLevel, message: message()))
+		logFormatted(.Error, message: message)
 	}
 }

--- a/AspenTests/AspenHelperTests.m
+++ b/AspenTests/AspenHelperTests.m
@@ -49,6 +49,8 @@
 	AspenVerbose(@"This should not print out: %@", [TestObjectFail new]);
 	AspenInfo(@"This should not print out: %@", [TestObjectFail new]);
 	AspenWarn(@"This should not print out: %@", [TestObjectFail new]);
+	
+	AspenError(@"This should print out: %@", [TestObjectPass new]);
 }
 
 - (void)testBuildWarnings {


### PR DESCRIPTION
• Rename outputToLog() -> logFormatted() which is less ambiguous
• Make logFormatted() and log() module-private to force use of convenience methods
• Separate public convenience functions to call them out as such
