### PR TITLE
Added exception handling for writing to a file

### DIFF
--- a/Aspen/AspenHelpers.h
+++ b/Aspen/AspenHelpers.h
@@ -32,4 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
 // Do not use AspenMaybe directly; use one of the other macros above
 #define AspenMaybe(level, format, ...) do { if ([Aspen willLog:level]) { [Aspen logWithLevel:level message:[NSString stringWithFormat:format, ##__VA_ARGS__]]; } } while (0)
 
+NS_INLINE NSException * _Nullable tryBlock(void(^_Nonnull tryBlock)(void)) {
+    @try {
+        tryBlock();
+    }
+    @catch (NSException *exception) {
+        return exception;
+    }
+    return nil;
+}
+
 NS_ASSUME_NONNULL_END

--- a/Aspen/FileLogger.swift
+++ b/Aspen/FileLogger.swift
@@ -56,7 +56,12 @@ public final class FileLogger: NSObject, LogInterface {
             handle.seekToEndOfFile()
             let messageWithNewLine = "\(message)\n"
             if let data = messageWithNewLine.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: false) {
-                handle.writeData(data)
+                let exception = tryBlock {
+                    handle.writeData(data)
+                }
+                if exception != nil {
+                    print("Error writing to log file \(exception)")
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary of Changes

Wrapped `NSFileHandle.writeData` in a try-catch block to handle Objective-C exceptions when there's no disk space or other write issue. 
### Addresses

Addresses writeData crashes such as:
`function signature specialization <Arg[0] = Owned To Guaranteed and Exploded> of Aspen.FileLogger.log (Aspen.FileLogger)(Swift.String) -> ()`
